### PR TITLE
reports-tooltip always open 

### DIFF
--- a/report-monthly.html
+++ b/report-monthly.html
@@ -299,7 +299,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -313,7 +313,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip" 
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -327,7 +327,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -341,7 +341,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -355,7 +355,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -370,7 +370,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>
@@ -384,7 +384,7 @@
                                                         <td>
                                                             <span class="icon icon-md icon-pdf-black me-0"
                                                                 data-bs-toggle="modal" data-bs-target="#invoiceModal"
-                                                                data-toggle="tooltip" tabindex="0"
+                                                                data-toggle="tooltip"
                                                                 title="SEE INVOICE"></span>
                                                         </td>
                                                     </tr>

--- a/report-payment.html
+++ b/report-payment.html
@@ -353,7 +353,7 @@
                                                             <div
                                                                 class="d-flex justify-content-end align-items-center me-1">
                                                                 <span class="icon icon-money-red cursor-pointer"
-                                                                    tabindex="0" data-toggle="tooltip"
+                                                                     data-toggle="tooltip"
                                                                     title="Complete payment" data-bs-toggle="modal"
                                                                     data-bs-target="#updatePayment"></span>
                                                                 <span class="icon icon-pdf-black me-0 cursor-pointer"


### PR DESCRIPTION
fix: tooltip always open issue in reports>reports-monthly & reports-payment page