### PR TITLE
fix: alignment of table header text and table body text in CTA completed tabs

### DIFF
--- a/cta.html
+++ b/cta.html
@@ -685,7 +685,7 @@
                                             <table id="completed-table" class="table table-striped table-nowrap w-100">
                                                 <thead>
                                                     <tr>
-                                                        <th class="fixed-max-width">Entity Name</th>
+                                                        <th class="fixed-max-width"><span class="ms-4 ps-3">&nbsp;Entity Name</span></th>
                                                         <th class="fixed-max-width">Group</th>
                                                         <th class="fixed-max-width">Type</th>
                                                         <th>State</th>


### PR DESCRIPTION
fix: alignment of table header text and table body text in CTA completed tabs