### PR TITLE
fix: hyperlinked removed from text 'unlimited update filings' in cta cap table slide-out

### DIFF
--- a/404-page.html
+++ b/404-page.html
@@ -458,8 +458,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/additional-services-select.html
+++ b/additional-services-select.html
@@ -1313,8 +1313,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/cta.html
+++ b/cta.html
@@ -4882,8 +4882,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                        class="text-decoration">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/entities.html
+++ b/entities.html
@@ -1150,8 +1150,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/group-details.html
+++ b/group-details.html
@@ -2222,8 +2222,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/groups.html
+++ b/groups.html
@@ -631,8 +631,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/index.html
+++ b/index.html
@@ -2802,8 +2802,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/org-chart-list.html
+++ b/org-chart-list.html
@@ -1234,8 +1234,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/registered-agent.html
+++ b/registered-agent.html
@@ -806,8 +806,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/report-monthly.html
+++ b/report-monthly.html
@@ -605,8 +605,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/report-payment.html
+++ b/report-payment.html
@@ -900,8 +900,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/reports.html
+++ b/reports.html
@@ -472,8 +472,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>

--- a/trade.html
+++ b/trade.html
@@ -2292,8 +2292,8 @@
 
                             <p>"Filejet is now offering Beneficial Ownership Information (BOI) filings for the Corporate
                                 Transparency Act !</p>
-                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><a
-                                        href="javascript:void(0)">unlimited update filings</a></b> for any
+                            <p>Filejet is providing the initial BOI filing (if applicable) and <b><span
+                                class="text-decoration-underline">unlimited update filings</span></b> for any
                                 non-exempt reporting companies for only $100 per year per entity. Billing is an annual
                                 subscription fee, per your existing Terms & Conditions.</p>
                             <p>It is fast and easy. Please click below to get started! "</p>


### PR DESCRIPTION
fix: hyperlinked removed from text 'unlimited update filings' in cta cap table slide-out