### PR TITLE
fix: dropdown disabled for month and year in daterange picker in CTA

### DIFF
--- a/cta.html
+++ b/cta.html
@@ -7201,11 +7201,11 @@
         $(function () {
             $('input[name="reminderDate"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calender-input'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'auto',
                 minYear: 1901,
@@ -7220,7 +7220,7 @@
         $(function () {
             $('input[name="filedDate"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calender-input-filed'),
@@ -7238,11 +7238,11 @@
         $(function () {
             $('input[name="dateOfBirth"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calender-input-dob'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'bottom',
                 minYear: 1901,
@@ -7257,11 +7257,11 @@
         $(function () {
             $('input[name="dateOfBirth2"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calendar-input3'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'bottom',
                 minYear: 1901,
@@ -7276,11 +7276,11 @@
         $(function () {
             $('input[name="expireDate"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calendar-input4'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'bottom',
                 minYear: 1901,
@@ -7295,11 +7295,11 @@
         $(function () {
             $('input[name="expireDate2"]').daterangepicker({
                 singleDatePicker: true,
-                showDropdowns: true,
+                // showDropdowns: true,
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calendar-input5'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'bottom',
                 minYear: 1901,
@@ -7316,7 +7316,7 @@
                 autoUpdateInput: false,
                 autoApply: true,
                 parentEl: $('.calendar-input-last-date'),
-                showDropdowns: true,
+                // showDropdowns: true,
                 applyButtonClasses: 'btn-info',
                 drops: 'bottom',
                 minYear: 1901,


### PR DESCRIPTION
fix: dropdown disabled for month and year in date range picker in CTA