### PR TITLE
fix: confirm button redirect to account security screen from single-sign-in screen

### DIFF
--- a/single-sign-in.html
+++ b/single-sign-in.html
@@ -54,7 +54,7 @@
                     </div>
                 </div>
                 <button type="button" class="btn btn-primary w-100 py-3 mt-2 nextBtn">Next</button>
-                <button type="button" class="btn btn-primary w-100 py-3 mt-2 d-none confirmBtn" onclick="window.location.href ='index.html'">Confirm</button>
+                <button type="button" class="btn btn-primary w-100 py-3 mt-2 d-none confirmBtn" onclick="window.location.href ='../account/account-security.html'">Confirm</button>
                 <div class="text-end text-uppercase mt-2 mb-4 d-none" id="forgotPasswordDiv">
                   <small>
                     <a href="./forget-password.html">Forgot password?


### PR DESCRIPTION
fix: confirm button redirect to account security screen from single-sign-in screen