### PR TITLE
fix: subsidiary modal linked to subsidiary icon in table in entity-details page

### DIFF
--- a/entities-details.html
+++ b/entities-details.html
@@ -510,6 +510,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -601,6 +602,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -698,6 +700,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -794,6 +797,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -884,6 +888,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -976,6 +981,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -1067,6 +1073,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -1158,6 +1165,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -1249,6 +1257,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>
@@ -1340,6 +1349,7 @@
                                                                                     class="icon m-0 cursor-pointer icon-subsidiary"
                                                                                     data-toggle="tooltip"
                                                                                     aria-label="Subsidiary"
+                                                                                     data-bs-toggle="modal" data-bs-target="#subsidiaryEntity"
                                                                                     data-bs-original-title="Subsidiary"></span>
                                                                             </a>
                                                                         </span>


### PR DESCRIPTION
fix: subsidiary modal linked to subsidiary icon in table in entity-details page