### PR TITLE
fix: search fields display entity name when search for enitity or something else

### DIFF
--- a/src/js/custom-org-chart-parent-child.js
+++ b/src/js/custom-org-chart-parent-child.js
@@ -159,6 +159,7 @@ var chart = new OrgChart(document.getElementById("tree"), {
     align: OrgChart.align.orientation,
     movable: OrgChart.movable.node,
     enableDragDrop: true,
+    searchDisplayField: 'Select_Entity',
     // scaleInitial: OrgChart.match.boundary,
     lazyLoading: true,
     enableSearch: true,


### PR DESCRIPTION
fix: search fields display entity name when search for enitity or something else