### PR TITLE
fix: when searched for a node listing of search suggestion getting hided when clicked

### DIFF
--- a/src/js/custom-org-chart-parent-child.js
+++ b/src/js/custom-org-chart-parent-child.js
@@ -301,7 +301,8 @@ chart.searchUI.on('show-items', function(sender){
 chart.searchUI.on('searchclick', function (sender, args) {
     let node = chart.get(args.nodeId);
     node.tags = ['match'];
-    chart.updateNode(node)
+    chart.updateNode(node);
+    sender.instance.searchUI.hide();
     // return false; 
 });  
 function callHandler(nodeId) {


### PR DESCRIPTION
fix: when searched for a node listing of search suggestion getting hided when clicked