### PR TITLE
fix: toggle button compress at 1366px resolution in org-chart reboot design

### DIFF
--- a/org-chart-reboot.html
+++ b/org-chart-reboot.html
@@ -264,7 +264,7 @@
                                     </ol>
                                 </nav>
                                 <div class="toggleBtns w-75 mb-3 d-flex align-item-center gap-3 flex-fill ms-5">
-                                    <div class="form-check form-switch w-25 flex-fill">
+                                    <div class="form-check form-switch w-50 flex-fill">
                                         <input class="form-check-input " type="checkbox" id="partnerBtn" checked>
                                         <label class="form-check-label text-nowrap" for="partnerBtn">Show Foreign Registrations</label>
                                     </div>


### PR DESCRIPTION
fix: toggle button compress at 1366px resolution in org-chart reboot design