### PR TITLE
fix: external entity node added into org-chart reboot design

### DIFF
--- a/data-reboot-v2.json
+++ b/data-reboot-v2.json
@@ -12,13 +12,13 @@
             { "id": 5, "pid":2, "entityName":"AIC Capital LLC (DE), LLC",  "Entity_Type":"LLC","state":"Florida","entityDescription":"", "tags":["partnerNode"]},
             { "id": 6, "pid":2, "entityName":"AIC Capital Multifamily Investment LLC (DE), LLC",  "Entity_Type":"LLC","state":"North Corolina","entityDescription":"", "tags":["partnerNode"]},
             
-            { "id": 7, "entityName":"AIC Capital LLC External Entity","Entity_Type":"LLC","state":"Delaware","entityDescription":"California Liability Limited", "tags":["externalChild"], "externalEntity":"-External", "createdAt": "10% Ownership"},
+            { "id": 7, "entityName":"AIC Capital LLC External Entity","Entity_Type":"LLC","state":"Delaware","entityDescription":"California Liability Limited", "tags":["externalEntityNode"], "externalEntity":"-External", "createdAt": "10% Ownership"},
     
             {"id": 8, "entityName":"AIC Multifamily Investment", "tags":["additionalOwners"],    "entityTitle":"Additional Owners", "html": "<ul class='lh-base'><li class='mb-0'>John Doe 15%</li><li>AIC LLC 15%</li><li>Investment LLC 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li></ul>"},
     
             { "id": 10,"entityName":"AIC Internal (DE), LLC", "Entity_Type":"LLC","state":"Delaware","entityDescription":"","createdAt": "60% Ownership" },
     
-            { "id":9, "entityName":"AIC LLC External Entity","Entity_Type":"LLC","state":"Delaware","entityDescription":"California Liability Limited", "tags":["externalChild"], "externalEntity":"-External", "createdAt": "10% Ownership"},
+            { "id":9, "entityName":"AIC LLC External Entity","Entity_Type":"LLC","state":"Delaware","entityDescription":"California Liability Limited", "tags":["externalEntityNode"], "externalEntity":"-External", "createdAt": "10% Ownership"},
     
             {"id": 11, "entityName":"AIC Internal (DE), LLC", "tags":["additionalOwners"],    "entityTitle":"Additional Owners", "html": "<ul class='lh-base'><li class='mb-0'>John Doe 15%</li><li>AIC LLC 15%</li><li>Investment LLC 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li><li>External Entity 15%</li><li>Filejet Entities 10%</li></ul>"},
     


### PR DESCRIPTION
fix: external entity node added into org-chart reboot design