### PR TITLE
fix: text overlap on nodes and open summary form disabled when click on node

### DIFF
--- a/src/js/custom-org-chart-reboot-v4.js
+++ b/src/js/custom-org-chart-reboot-v4.js
@@ -54,26 +54,11 @@ OrgChart.miniMap.position = {
 }
 
 // start olivia > cyan color rectangle templates
-// var tooltip = 
-//   `<g data-t-id="{id}" transform="matrix(0.001,0,0,0.001,{x},{y})" >
-//   {text}</g>`;
-// var tooltipText = '<text text-anchor="middle" data-width="130" fill="#000" class="bg-dark fs-7" x="0" y="0">{val}</text>';
-// var tooltipText = `
-//   <defs>
-//     <filter x="0" y="0" width="1" height="1.5" id="solid">
-//       <feFlood flood-color="#000" result="bg" />
-//       <feMerge>
-//         <feMergeNode in="bg"/>
-//         <feMergeNode in="SourceGraphic"/>
-//       </feMerge>
-//     </filter>
-//   </defs>
-//   '<text filter="url(#solid)" text-anchor="middle" class="font-weight-400 fs-7" data-width="130" data-text-overflow="multiline" fill="#fff" x="0" y="-10">{val}</text>'
-// `
+
 OrgChart.templates.olivia.size = [320, 90];
 OrgChart.templates.olivia.nodeMenuButton = '<g transform="matrix(1,0,0,1,280,45)" data-ctrl-n-menu-id="{id}"><rect x="-4" y="-10" fill="#fff" fill-opacity="0" width="22" height="22"></rect><circle cx="0" cy="0" r="2" fill="#fff"></circle><circle cx="7" cy="0" r="2" fill="#fff"></circle><circle cx="14" cy="0" r="2" fill="#fff"></circle></g>';
 OrgChart.templates.olivia.entityName = '<text data-width="240" data-marrk-field="entityName" class="fs-5 font-weight-500 text-white" data-text-overflow="ellipsis" x="15" y="30" fill="#fff">{val}</text>';
-OrgChart.templates.olivia.state = '<text data-width="100" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="60">{val}</text>';
+OrgChart.templates.olivia.state = '<text data-width="70" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="60">{val}</text>';
 OrgChart.templates.olivia.entityType = '<text data-width="200" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" width="180" height="25" x="85" y="60">{val}</text>';
 OrgChart.templates.olivia.node =
     `<rect x="0" y="0" height="{h}" width="{w}" fill="#039BE5" stroke-width="1" stroke="#039BE5" rx="10" ry="10"></rect>`;
@@ -90,12 +75,12 @@ OrgChart.templates.individualOwners = Object.assign({}, OrgChart.templates.olivi
 OrgChart.templates.individualOwners.size = [320, 110];
 OrgChart.templates.individualOwners.nodeMenuButton = '<g transform="matrix(1,0,0,1,280,55)" data-ctrl-n-menu-id="{id}"><rect x="-4" y="-10" fill="#fff" fill-opacity="0" width="22" height="22"></rect><circle cx="0" cy="0" r="2" fill="#fff"></circle><circle cx="7" cy="0" r="2" fill="#fff"></circle><circle cx="14" cy="0" r="2" fill="#fff"></circle></g>';
 OrgChart.templates.individualOwners.entityName = '<text data-width="240" data-marrk-field="entityName" class="fs-5 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="25" width="230" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.individualOwners.state = '<text data-width="240" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="45">{val}</text>';
-OrgChart.templates.individualOwners.entityType = '<text data-width="240" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="45">{val}</text>';
+OrgChart.templates.individualOwners.state = '<text data-width="63" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="45">{val}</text>';
+OrgChart.templates.individualOwners.entityType = '<text data-width="180" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="45">{val}</text>';
 
 OrgChart.templates.individualOwners.individualOwnerName = '<text data-width="240" data-marrk-field="individualOwnerName" class="fs-5 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="75" width="230" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.individualOwners.individualType = '<text data-width="240" data-marrk-field="individualType" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="92" width="150" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.individualOwners.ownershipPercentage = '<text data-width="240" data-marrk-field="ownershipPercentage" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="140" y="92" width="230" height="25" fill="#fff">{val}</text>';
+OrgChart.templates.individualOwners.individualType = '<text data-width="110" data-marrk-field="individualType" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="92" width="150" height="25" fill="#fff">{val}</text>';
+OrgChart.templates.individualOwners.ownershipPercentage = '<text data-width="180" data-marrk-field="ownershipPercentage" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="140" y="92" width="230" height="25" fill="#fff">{val}</text>';
 
 OrgChart.templates.individualOwners.visualIndicator = '<foreignobject data-width="30" data-marrk-field="visualIndicator" class="fs-5 font-weight-500 text-dark" data-text-overflow="ellipsis" fill="#18d6c3" width="30" height="25" x="282" y="0">{val}</foreignobject>';
 OrgChart.templates.individualOwners.node =
@@ -113,11 +98,11 @@ OrgChart.templates.externalIndividualOwners = Object.assign({}, OrgChart.templat
 OrgChart.templates.externalIndividualOwners.size = [320, 110];
 OrgChart.templates.externalIndividualOwners.nodeMenuButton = '<g transform="matrix(1,0,0,1,280,55)" data-ctrl-n-menu-id="{id}"><rect x="-4" y="-10" fill="#fff" fill-opacity="0" width="22" height="22"></rect><circle cx="0" cy="0" r="2" fill="#fff"></circle><circle cx="7" cy="0" r="2" fill="#fff"></circle><circle cx="14" cy="0" r="2" fill="#fff"></circle></g>';
 OrgChart.templates.externalIndividualOwners.entityName = '<text data-width="240" data-marrk-field="entityName" class="fs-5 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="25" width="230" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.externalIndividualOwners.state = '<text data-width="240" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="45">{val}</text>';
-OrgChart.templates.externalIndividualOwners.entityType = '<text data-width="240" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="45">{val}</text>';
+OrgChart.templates.externalIndividualOwners.state = '<text data-width="63" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="45">{val}</text>';
+OrgChart.templates.externalIndividualOwners.entityType = '<text data-width="220" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="45">{val}</text>';
 OrgChart.templates.externalIndividualOwners.individualOwnerName = '<text data-width="240" data-marrk-field="individualOwnerName" class="fs-5 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="75" width="230" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.externalIndividualOwners.individualType = '<text data-width="240" data-marrk-field="individualType" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="92" width="150" height="25" fill="#fff">{val}</text>';
-OrgChart.templates.externalIndividualOwners.ownershipPercentage = '<text data-width="240" data-marrk-field="ownershipPercentage" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="140" y="92" width="230" height="25" fill="#fff">{val}</text>';
+OrgChart.templates.externalIndividualOwners.individualType = '<text data-width="110" data-marrk-field="individualType" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="92" width="150" height="25" fill="#fff">{val}</text>';
+OrgChart.templates.externalIndividualOwners.ownershipPercentage = '<text data-width="180" data-marrk-field="ownershipPercentage" class="fs-6 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="140" y="92" width="230" height="25" fill="#fff">{val}</text>';
 OrgChart.templates.externalIndividualOwners.visualIndicator = '<foreignobject data-width="30" data-marrk-field="visualIndicator" class="fs-5 font-weight-500 text-dark" data-text-overflow="ellipsis" fill="#18d6c3" width="30" height="25" x="282" y="0">{val}</foreignobject>';
 OrgChart.templates.externalIndividualOwners.node =
     `<rect x="0" y="0" height="{h}" width="{w}" fill="#F57C00" stroke-width="1" stroke="#F57C00" rx="10" ry="10"></rect>`;
@@ -134,7 +119,7 @@ OrgChart.templates.ula.min = Object.assign({}, OrgChart.templates.ula);
 OrgChart.templates.ula.min.size = [320, 60];
 OrgChart.templates.ula.nodeMenuButton = '<g transform="matrix(1,0,0,1,280,47)" data-ctrl-n-menu-id="{id}"><rect x="-4" y="-10" fill="#000000" fill-opacity="0" width="22" height="22"></rect><circle cx="0" cy="0" r="2" fill="#fff"></circle><circle cx="7" cy="0" r="2" fill="#fff"></circle><circle cx="14" cy="0" r="2" fill="#fff"></circle></g>';
 OrgChart.templates.ula.entityName = '<text data-marrk-field="entityName" data-width="230" class="fs-5 font-weight-500 text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="30" fill="#fff">{val}</text>';
-OrgChart.templates.ula.state = '<text data-width="240" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="60">{val}</text>';
+OrgChart.templates.ula.state = '<text data-width="65" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="15" y="60">{val}</text>';
 OrgChart.templates.ula.entityType = '<text data-width="50" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="60">{val}</text>';
 OrgChart.templates.ula.externalEntity= '<text data-width="200" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="140" y="60">{val}</foreignobject>';
 
@@ -152,7 +137,7 @@ OrgChart.templates.polina.size = [300, 70];
 OrgChart.templates.polina.nodeMenuButton = '<g transform="matrix(1,0,0,1,270,35)" data-ctrl-n-menu-id="{id}"><rect x="-4" y="-10" fill="#000000" fill-opacity="0" width="22" height="22"></rect><circle cx="0" cy="0" r="2" fill="#fff"></circle><circle cx="7" cy="0" r="2" fill="#fff"></circle><circle cx="14" cy="0" r="2" fill="#fff"></circle></g>';
 OrgChart.templates.polina.entityName = '<text data-marrk-field="entityName" data-width="200" class="fs-5 font-weight-500 text-white" data-text-overflow="ellipsis" x="25" y="25" fill="#fff">{val}</text>';
 OrgChart.templates.polina.entityType = '<text data-width="240" data-marrk-field="Entity_Type" class="fs-6 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#fff" x="85" y="50">{val}</text>';
-OrgChart.templates.polina.state = '<text data-width="240" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="25" y="50">{val}</text>';
+OrgChart.templates.polina.state = '<text data-width="60" data-marrk-field="state" class="fs-6 text-white" fill="#fff" x="25" y="50">{val}</text>';
 OrgChart.templates.polina.link = '<path stroke-linejoin="round" stroke="#000" stroke-width="1px" fill="none" d="{rounded}" />';
 OrgChart.templates.polina.icons_0 = '<foreignobject data-width="60" class="d-block text-end" fill="#000000" width="60" height="28" x="225" y="5">{val}</foreignobject>';
 
@@ -174,10 +159,9 @@ OrgChart.templates.polina.plus = '<circle cx="15" cy="15" r="15" fill="#FFFFFF" 
 // start additional owner >green one edge cut rectangle > additional owner
 OrgChart.templates.additionalOwners = Object.assign({}, OrgChart.templates.ana);
 OrgChart.templates.additionalOwners.size = [270, 95];
-OrgChart.templates.additionalOwners.entityName = '<foreignobject data-marrk-field="entityName" data-width="230" class="fs-5 font-weight-500 fst-italic text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="0" width="285" height="25" fill="#000000"><div>{val}</div></foreignobject>';
+OrgChart.templates.additionalOwners.entityName = '<text data-marrk-field="entityName" data-width="230" class="fs-5 font-weight-500 fst-italic text-white entityNameEllipsis" data-text-overflow="ellipsis" x="15" y="20" width="285" height="25" fill="#fff">{val}</text>';
 OrgChart.templates.additionalOwners.entityTitle = '<foreignobject data-width="240" data-marrk-field="EntityTitle" class="fs-9 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#000000" width="230" height="22" x="15" y="20">{val}</foreignobject>';
-OrgChart.templates.additionalOwners.entityTitle = '<foreignobject data-width="240" data-marrk-field="EntityTitle" class="fs-9 font-weight-400 text-white" data-text-overflow="ellipsis" fill="#000000" width="230" height="22" x="15" y="20">{val}</foreignobject>';
-OrgChart.templates.additionalOwners.html = '<foreignobject data-width="240" data-marrk-field="html" class="fs-7 font-weight-400 pt-0 additionalItems text-white" data-text-overflow="ellipsis" fill="#000000" width="255" height="54" x="15" y="40">{val}</foreignobject>';
+OrgChart.templates.additionalOwners.html = '<foreignobject data-width="230" data-marrk-field="html" class="fs-7 font-weight-400 pt-0 additionalItems text-white" data-text-overflow="ellipsis" fill="#000000" width="255" height="54" x="15" y="40">{val}</foreignobject>';
 // OrgChart.templates.additionalOwners.state = '<foreignobject data-width="240" data-marrk-field="state" class="fs-6 text-white" fill="#000000" width="65" height="25" x="134" y="20">{val}</foreignobject>';
 OrgChart.templates.additionalOwners.link = '<path marker-start="url(#dotSlinkYellow)" marker-end="url(#arrowSlinkYellow)"  stroke-linejoin="round" stroke="#000" stroke-width="1px" fill="none" d="{rounded}" />';
 OrgChart.templates.additionalOwners.visualIndicator = '<foreignobject data-width="30" data-marrk-field="visualIndicator" class="fs-5 font-weight-500 text-dark" data-text-overflow="ellipsis" fill="#18D6C3" width="30" height="25" x="250" y="0">{val}</foreignobject>';
@@ -542,6 +526,13 @@ var chart = new OrgChart(document.getElementById("tree"), {
     // },
 });
 
+// onclick on node dont open summary form
+chart.onNodeClick((args) => {
+    //chart.editUI.show(args.node.id, false); 
+    sender.editUI.show(args.node.id, true); 
+    return false; //to cansel the click event
+});
+// end
 
 // toggle button show/hide partner & slinks nodes
 let partnerNodeState = 'polina';


### PR DESCRIPTION
fix: text overlap on nodes and open summary form disabled when click on node